### PR TITLE
use squigly heredoc, fixes #5

### DIFF
--- a/puma-dev.rb
+++ b/puma-dev.rb
@@ -18,7 +18,7 @@ class PumaDev < Formula
   end
 
   def caveats
-    <<-EOS.undent
+    <<~EOS
       Setup dev domains:
         sudo puma-dev -setup
 


### PR DESCRIPTION
Given homebrew [must be run under ruby 2.3](https://github.com/Homebrew/brew/blob/0cd50400c7c1727ec602a9f8dcdc08678622d61e/Library/Homebrew/brew.rb#L12) as of https://github.com/Homebrew/brew/commit/bcca2a7c6b80a6450bd8261af987a8da260b6b89 using `<<~EOS` should be safe.