### PR TITLE
v0.15.1

### DIFF
--- a/puma-dev.rb
+++ b/puma-dev.rb
@@ -1,9 +1,9 @@
 class PumaDev < Formula
   desc "A tool to manage rack apps in development with puma"
   homepage "https://github.com/puma/puma-dev"
-  url "https://github.com/puma/puma-dev/releases/download/v0.15/puma-dev-0.15-darwin-amd64.zip"
-  sha256 "5d694b4d790465d403fcc55da65b97bfe9fcf5cc9f6cae6aeda6d2780e7bae62"
-  version '0.15'
+  url "https://github.com/puma/puma-dev/releases/download/v0.15.1/puma-dev-0.15.1-darwin-amd64.zip"
+  sha256 "a9348e67431ee65f6f41e2ad758d5c4212996d2c2c92e51229a412bd342c7864"
+  version '0.15.1'
 
   def install
     bin.install "puma-dev"


### PR DESCRIPTION
```
$ puma-dev -V; puma-dev -no-serve-public-paths="/packs"
Version: 0.15.1 (go1.15.3)
2020/10/29 08:45:43 Existing valid puma-dev CA keypair found. Assuming previously trusted.
* Directory for apps: /Users/norton/.puma-dev
* Domains: test
* DNS Server port: 9253
* HTTP Server port: 9280
* HTTPS Server port: 9283
* Ignoring files under: public{/packs}
! Puma dev running...
```